### PR TITLE
bind this in read/write/exec to Object Instance itself

### DIFF
--- a/lib/object_instance.js
+++ b/lib/object_instance.js
@@ -77,11 +77,19 @@ ObjectInstance.prototype.init = function (resrcs, opt) {
         if (_.isObject(rVal))
             rVal._isCb = _.isFunction(rVal.read) || _.isFunction(rVal.write) || _.isFunction(rVal.exec);
 
+        if (_.isFunction(rVal.read))
+            rVal.read = rVal.read.bind(self);
+
+        if (_.isFunction(rVal.write))
+            rVal.write = rVal.write.bind(self);
+
+        if (_.isFunction(rVal.exec))
+            rVal.exec = rVal.exec.bind(self);
+
         self.set(rKey, rVal);   // set will turn rid to string
     });
 };
 
-// (V)
 ObjectInstance.prototype.dump = function (opt, callback) {
     // do not dump keys: 'oid', 'iid'
     var self = this,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartobject",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A Smart Object Class that helps you with creating IPSO Smart Objects in your JavaScript applications",
   "main": "index.js",
   "scripts": {

--- a/test/objectInstCbBind.test.js
+++ b/test/objectInstCbBind.test.js
@@ -1,0 +1,58 @@
+var _ = require('busyman'),
+    expect = require('chai').expect, 
+    SmartObject = require('../index.js'); 
+
+var smartObj = new SmartObject();
+
+describe('Smart Object - Instance read/write/exec cb bind this to instance itself', function () {
+    describe('#read', function () {
+        it('should bind this to instance itself in read method', function (done) {
+            smartObj.init(3303, 0, { 
+                5700: {
+                    read: function (cb) {
+                        cb(null, this);
+                    }    
+                }
+            });
+
+            smartObj.read(3303, 0, 5700, function (err, val) {
+                if (val === smartObj['temperature'][0])
+                    done();
+            });
+        });
+    });
+
+    describe('#write', function () {
+        it('should bind this to instance itself in write method', function (done) {
+            smartObj.init('positioner', 1, { 
+                5536: {
+                    write: function (val, cb) {
+                        cb(null, this);
+                    }
+                }
+            });
+
+            smartObj.write('positioner', 1, 5536, 10, function (err, val) {
+                if (val === smartObj['positioner'][1])
+                    done();
+            });
+        });
+    });
+
+    describe('#exec', function () {
+        it('should bind this to instance itself in exec method', function (done) {
+            smartObj.init('positioner', 2, { 
+                5605: {
+                    exec: function (cb) {
+                        cb(null, this);
+                    }
+                }
+            });
+
+            smartObj.exec('positioner', 2, 5605, [], function (err, val) {
+                if (val === smartObj['positioner'][2])
+                    done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Bind this in read/write/exec method, thus users can access to the Object Instance without calling `so.read(oid, iid, rid, cb)`.

For example:

```js
var so = new SmartObject();

so.init('myObject', 0, {    // oid = 'myObject', iid = 0
    myResrc1: 20,
    myResrc2: {
        read: function (cb) {
            console.log(this.myResrc1);  // 20, this is point to the Object Instance itself
            cb();
        }
    }
});
```