### PR TITLE
fix read/write/exec binding fails if rVal is not an object

### DIFF
--- a/lib/object_instance.js
+++ b/lib/object_instance.js
@@ -74,17 +74,18 @@ ObjectInstance.prototype.init = function (resrcs, opt) {
                 throw new TypeError('Resource id: ' + rKey + ' is not an IPSO-defined resource.');
         }
 
-        if (_.isObject(rVal))
+        if (_.isObject(rVal)) {
             rVal._isCb = _.isFunction(rVal.read) || _.isFunction(rVal.write) || _.isFunction(rVal.exec);
 
-        if (_.isFunction(rVal.read))
-            rVal.read = rVal.read.bind(self);
+            if (_.isFunction(rVal.read))
+                rVal.read = rVal.read.bind(self);
 
-        if (_.isFunction(rVal.write))
-            rVal.write = rVal.write.bind(self);
+            if (_.isFunction(rVal.write))
+                rVal.write = rVal.write.bind(self);
 
-        if (_.isFunction(rVal.exec))
-            rVal.exec = rVal.exec.bind(self);
+            if (_.isFunction(rVal.exec))
+                rVal.exec = rVal.exec.bind(self);
+        }
 
         self.set(rKey, rVal);   // set will turn rid to string
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartobject",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Smart Object Class that helps you with creating IPSO Smart Objects in your JavaScript applications",
   "main": "index.js",
   "scripts": {

--- a/test/objectInstCbBind.test.js
+++ b/test/objectInstCbBind.test.js
@@ -8,8 +8,10 @@ describe('Smart Object - Instance read/write/exec cb bind this to instance itsel
     describe('#read', function () {
         it('should bind this to instance itself in read method', function (done) {
             smartObj.init(3303, 0, { 
+                a: 'hello world',
                 5700: {
                     read: function (cb) {
+                        console.log(this.a);
                         cb(null, this);
                     }    
                 }


### PR DESCRIPTION
Put binding in `if (_.isObject(rVal)) {}`